### PR TITLE
[GITHUB-13] add quotation marks and jinja delimiters around bare variables

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,7 +29,7 @@
     creates: "{{ kibana.install_dir }}/installedPlugins/{{ item.plugin_dir }}"
   environment:
     JAVA_HOME: /usr/share/java
-  with_items: kibana.plugins
+  with_items: "{{ kibana.plugins }}"
 
 - name: Ensure Systemd Service Configuraiton
   become: yes


### PR DESCRIPTION
In order to use this role with Ansible 2.2, any bare variables used as "with_items" in loops need to be quoted.