### PR TITLE
adding back shebang to service j2 template

### DIFF
--- a/templates/kibana_sysv.j2
+++ b/templates/kibana_sysv.j2
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 ### BEGIN INIT INFO
 # Provides:          kibana
 # Required-Start:    $network
@@ -34,7 +36,7 @@ do_start()
 
 
 do_stop () {
-  pkill node 
+  pkill node
 }
 
 case "$1" in


### PR DESCRIPTION
You forgot the shebang in the service template and the service won't start out of the box on ubuntu with systemctl as it will kick an error similar to this ```May 02 18:11:33 vagrant systemd[18842]: kibana.service: Failed at step EXEC spawning /etc/init.d/kibana: Exec format error```